### PR TITLE
Fix: .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@
 /XDE/xde.conf.local
 /XDE/generated-system/
 /XDE/generated-user/
-system-backup-*
-user-backup-*
-
+backup-system*
+backup-user*


### PR DESCRIPTION
The file name in the `.gitignore` does not match the actual file name. fit it. Fix it here.