### PR TITLE
关闭 (U)XTerm 的全屏功能

### DIFF
--- a/XDE/user/.Xresources.tmpl
+++ b/XDE/user/.Xresources.tmpl
@@ -49,6 +49,7 @@ XTerm*scrollTtyOutput    :  false
 XTerm*highlightSelection :  true
 XTerm*trimSelection      :  true
 XTerm*eightBitInput      :  false
+XTerm*fullscreen         :  never
 
 !! uxterm
 UXTerm*loginShell         :  true
@@ -84,6 +85,7 @@ UXTerm*scrollTtyOutput    :  false
 UXTerm*highlightSelection :  true
 UXTerm*trimSelection      :  true
 UXTerm*eightBitInput      :  false
+UXTerm*fullscreen         :  never
 
 !! urxvt
 ! URxvt renders Noto Sans Mono CJK SC very ugly, so we choose UMing.


### PR DESCRIPTION
alt+enter在zsh的查找历史里会用到，功能是选择历史命令并编辑。不屏蔽全屏功能时，无法正常使用。另外i3有自己的全屏快捷键。